### PR TITLE
57 user confirmation for large directories

### DIFF
--- a/mdaviz/mainwindow.py
+++ b/mdaviz/mainwindow.py
@@ -128,7 +128,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         popup = PopUp(self, message)
         return popup.exec_() == QtWidgets.QDialog.Accepted
-        
+
     def proceed(self):
         """Handle the logic when the user clicks 'OK'."""
         return True
@@ -198,9 +198,13 @@ class MainWindow(QtWidgets.QMainWindow):
                 n_files = len([*folder_path.iterdir()])
                 answer = True
                 if n_files > MAX_FILES:
-                    answer = self.doPopUp(f"The selected folder contains {n_files} files. \nDo you want to proceed?")
+                    answer = self.doPopUp(
+                        f"The selected folder contains {n_files} files. \nDo you want to proceed?"
+                    )
                 if answer:
-                    mda_list = [utils.get_file_info(f) for f in folder_path.glob("*.mda")]
+                    mda_list = [
+                        utils.get_file_info(f) for f in folder_path.glob("*.mda")
+                    ]
                     if mda_list:
                         self.setDataPath(folder_path)
                         mda_list = sorted(mda_list, key=lambda x: x["Name"])
@@ -218,10 +222,10 @@ class MainWindow(QtWidgets.QMainWindow):
                             self.mvc_folder.updateFolderView()
                     else:
                         self.info.setText("No mda files")
-                        self.doPopUp(f"No MDA files found.")
+                        self.doPopUp("No MDA files found.")
                         self.reset_mainwindow()
                         self.setStatus(f"\n{str(folder_path)!r} - No MDA files found.")
-                        
+
                 else:
                     self.reset_mainwindow()
                     self.setStatus("Operation canceled.")

--- a/mdaviz/mainwindow.py
+++ b/mdaviz/mainwindow.py
@@ -208,7 +208,6 @@ class MainWindow(QtWidgets.QMainWindow):
         - Re-fetch the list of MDA files in the current folder.
         - Display the updated file list in the MDA folder table view.
         """
-        # TODO: could be more efficient (i.e. ignore mda files already loaded)
         self.setStatus("Refreshing folder...")
         current_folder = self.dataPath()
         if current_folder:

--- a/mdaviz/mda_folder.py
+++ b/mdaviz/mda_folder.py
@@ -423,7 +423,6 @@ class MDA_MVC(QtWidgets.QWidget):
         # selectionField() may have changed when calling addFileTab
         if self.selectionField():
             if old_pv_list is not None:
-                # TODO - later: find out why this sometimes fails - not that important:
                 try:
                     self.updateSelectionForNewPVs(
                         old_selection, old_pv_list, new_pv_list, verbose

--- a/mdaviz/popup.py
+++ b/mdaviz/popup.py
@@ -1,4 +1,3 @@
-
 from PyQt5 import QtWidgets
 
 from . import utils
@@ -15,11 +14,11 @@ class PopUp(QtWidgets.QDialog):
 
         super().__init__(parent)
         utils.myLoadUi(self.ui_file, baseinstance=self)
-        
+
         self.message.setText(message)
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
-        
+
     def accept(self):
         """OK button was clicked"""
         super().accept()

--- a/mdaviz/popup.py
+++ b/mdaviz/popup.py
@@ -1,0 +1,31 @@
+
+from PyQt5 import QtWidgets
+
+from . import utils
+
+
+class PopUp(QtWidgets.QDialog):
+    """Load a generic About... Dialog as a .ui file."""
+
+    # UI file name matches this module, different extension
+    ui_file = utils.getUiFileName(__file__)
+
+    def __init__(self, parent, message):
+        self.parent = parent
+
+        super().__init__(parent)
+        utils.myLoadUi(self.ui_file, baseinstance=self)
+        
+        self.message.setText(message)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
+        
+    def accept(self):
+        """OK button was clicked"""
+        super().accept()
+        self.parent.proceed()
+
+    def reject(self):
+        """Cancel button was clicked"""
+        super().reject()
+        self.parent.cancel()

--- a/mdaviz/resources/popup.ui
+++ b/mdaviz/resources/popup.ui
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>530</width>
+    <height>113</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="message">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
- close #57

There is still one bug that annoys me, but can't find where it comes from. It is minor enough that I guess it can be turn into an issues:

```python
(mdaviz) (base) iMac:mdaviz fannysimoes$ mdaviz /Users/fannysimoes/src/mdaviz/mdaviz/data/test_no_positioner/
Settings are saved in: /Users/fannysimoes/.config/BCDA-APS/mdaviz.ini
Application started, loading /Users/fannysimoes/src/mdaviz/mdaviz/data/test_no_positioner ...
Please select a folder...
2024-06-12 16:03:14.587 python3.11[44515:450043] +[CATransaction synchronize] called within transaction

'.' - No MDA files found.

'/Users/fannysimoes' - No MDA files found.
```